### PR TITLE
Add mLLMCelltype paper to Single-cell section

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,10 +324,10 @@ Papers are ranked chronologically.
   [![](https://img.shields.io/badge/code-38C26D?style=flat&logo=GitHub&labelColor=555555)](https://github.com/OmicsML/CellPLM)
   [![Stars](https://img.shields.io/github/stars/OmicsML/CellPLM?color=yellow&style=social)](https://github.com/OmicsML/CellPLM)
  
-* **Large Language Model Consensus Substantially Improves the Cell Type Annotation Accuracy for scRNA-seq Data**
+* **(mLLMCelltype) Large Language Model Consensus Substantially Improves the Cell Type Annotation Accuracy for scRNA-seq Data**
   
-  [![](https://img.shields.io/badge/BioRxiv_2025-5291C8?style=flat&logo=Read.cv&labelColor=555555)](https://www.biorxiv.org/content/10.1101/2025.04.10.647852v1)
-  ![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.semanticscholar.org%2Fgraph%2Fv1%2Fpaper%2F%3Ffields%3DcitationCount&query=%24.citationCount&label=citation&style=social&labelColor=555555&color=ED8936)
+  [![](https://img.shields.io/badge/bioRxiv_2025-5291C8?style=flat&logo=Read.cv&labelColor=555555)](https://www.biorxiv.org/content/10.1101/2025.04.10.647852v1)
+  ![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.semanticscholar.org%2Fgraph%2Fv1%2Fpaper%2FDOI%3A10.1101%2F2025.04.10.647852%3Ffields%3DcitationCount&query=%24.citationCount&label=Citations&style=social&labelColor=555555&color=ED8936)
   [![](https://img.shields.io/badge/code-38C26D?style=flat&logo=GitHub&labelColor=555555)](https://github.com/cafferychen777/mLLMCelltype)
   [![Stars](https://img.shields.io/github/stars/cafferychen777/mLLMCelltype?color=yellow&style=social)](https://github.com/cafferychen777/mLLMCelltype)
 

--- a/README.md
+++ b/README.md
@@ -324,6 +324,13 @@ Papers are ranked chronologically.
   [![](https://img.shields.io/badge/code-38C26D?style=flat&logo=GitHub&labelColor=555555)](https://github.com/OmicsML/CellPLM)
   [![Stars](https://img.shields.io/github/stars/OmicsML/CellPLM?color=yellow&style=social)](https://github.com/OmicsML/CellPLM)
  
+* **Large Language Model Consensus Substantially Improves the Cell Type Annotation Accuracy for scRNA-seq Data**
+  
+  [![](https://img.shields.io/badge/BioRxiv_2025-5291C8?style=flat&logo=Read.cv&labelColor=555555)](https://www.biorxiv.org/content/10.1101/2025.04.10.647852v1)
+  ![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.semanticscholar.org%2Fgraph%2Fv1%2Fpaper%2F%3Ffields%3DcitationCount&query=%24.citationCount&label=citation&style=social&labelColor=555555&color=ED8936)
+  [![](https://img.shields.io/badge/code-38C26D?style=flat&logo=GitHub&labelColor=555555)](https://github.com/cafferychen777/mLLMCelltype)
+  [![Stars](https://img.shields.io/github/stars/cafferychen777/mLLMCelltype?color=yellow&style=social)](https://github.com/cafferychen777/mLLMCelltype)
+
 * **Assessing GPT-4 for cell type annotation in single-cell RNA-seq analysis**
   
   [![](https://img.shields.io/badge/Nature_Methods_2024-5291C8?style=flat&logo=Read.cv&labelColor=555555)](https://www.nature.com/articles/s41592-024-02235-4)

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Papers are ranked chronologically.
 * **(mLLMCelltype) Large Language Model Consensus Substantially Improves the Cell Type Annotation Accuracy for scRNA-seq Data**
   
   [![](https://img.shields.io/badge/bioRxiv_2025-5291C8?style=flat&logo=Read.cv&labelColor=555555)](https://www.biorxiv.org/content/10.1101/2025.04.10.647852v1)
-  ![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.semanticscholar.org%2Fgraph%2Fv1%2Fpaper%2FDOI%3A10.1101%2F2025.04.10.647852%3Ffields%3DcitationCount&query=%24.citationCount&label=Citations&style=social&labelColor=555555&color=ED8936)
+  ![Dynamic JSON Badge](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.semanticscholar.org%2Fgraph%2Fv1%2Fpaper%2Ffe35cb0df5b3dabe3cf1f8ea2e43e862c0400f1a%3Ffields%3DcitationCount&query=%24.citationCount&label=citation&style=social&labelColor=555555&color=ED8936)
   [![](https://img.shields.io/badge/code-38C26D?style=flat&logo=GitHub&labelColor=555555)](https://github.com/cafferychen777/mLLMCelltype)
   [![Stars](https://img.shields.io/github/stars/cafferychen777/mLLMCelltype?color=yellow&style=social)](https://github.com/cafferychen777/mLLMCelltype)
 


### PR DESCRIPTION
Add the paper "Large Language Model Consensus Substantially Improves the Cell Type Annotation Accuracy for scRNA-seq Data" to the Single-cell section. This paper introduces an iterative multi-LLM consensus framework for cell type annotation in single-cell RNA sequencing data that significantly improves annotation accuracy by leveraging the complementary strengths of multiple large language models.